### PR TITLE
Added cross-platform post-install script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "8"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ʆ Locus
 =======
 
+[![Build Status](https://travis-ci.org/rgrannell1/locus.svg?branch=master)](https://travis-ci.org/rgrannell1/locus)
+[![Inline docs](http://inch-ci.org/github/rgrannell1/locus.svg?branch=master)](http://inch-ci.org/github/rgrannell1/locus)
+
 Locus is a debugging module which allows you to execute commands at runtime via a REPL.
 
 [![asciicast](screenshot.png)](https://asciinema.org/a/102735?autoplay=1&speed=1.5)

--- a/constants.js
+++ b/constants.js
@@ -13,8 +13,9 @@ const units = {
 const constants = {
 	tests: {
 		variables: {
-			duration: 100 * units.S_IN_MS,
-			randomCaseCount: 10000
+			duration:              100 * units.S_IN_MS,
+			failedParseThreshold:  0.05,
+			randomCaseCount:       10000
 		}
 	}
 }

--- a/constants.js
+++ b/constants.js
@@ -13,7 +13,7 @@ const units = {
 const constants = {
 	tests: {
 		variables: {
-			duration:              100 * units.S_IN_MS,
+			duration:              	100 * units.S_IN_MS,
 			failedParseThreshold:  0.05,
 			randomCaseCount:       10000
 		}

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,26 @@
+
+'use strict'
+
+
+
+
+const units = {
+	S_IN_MS: 1000
+}
+
+
+
+const constants = {
+	tests: {
+		variables: {
+			duration: 100 * units.S_IN_MS,
+			randomCaseCount: 10000
+		}
+	}
+}
+
+
+
+
+
+module.exports = constants

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cardinal": "^1.0.0",
     "cli-color": "^1.0.0",
     "deasync": "^0.1.0",
+    "error-stack-parser": "^2.0.1",
     "escope": "^3.6.0",
     "esprima": "^3.1.3",
     "estraverse": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Line focuser",
   "main": "src/locus.js",
   "scripts": {
-    "postinstall": "mkdir ./histories"
+    "postinstall": "node ./src/postinstall.js"
   },
   "files": [
     "src/"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Line focuser",
   "main": "src/locus.js",
   "scripts": {
-    "postinstall": "node ./src/postinstall.js"
+    "postinstall": "node ./src/postinstall.js",
+    "test": "node_modules/mocha/bin/mocha test"
   },
   "files": [
     "src/"
@@ -12,17 +13,23 @@
   "dependencies": {
     "bindings": "^1.2.1",
     "cardinal": "^1.0.0",
+    "chai": "^4.1.2",
     "cli-color": "^1.0.0",
     "deasync": "^0.1.0",
     "error-stack-parser": "^2.0.1",
     "escope": "^3.6.0",
+    "esfuzz": "^0.3.1",
+    "espree": "^3.5.1",
     "esprima": "^4.0.0",
     "estraverse": "^4.2.0",
     "lodash": "^4.17.3",
     "md5": "^2.2.1",
+    "mocha": "^4.0.1",
     "parse-stack": "^0.1.4",
     "prompt": "^1.0.0",
-    "readline-history": "^1.2.0"
+    "readline-history": "^1.2.0",
+    "uglify-js": "^3.1.3",
+    "uglifyjs": "^2.4.11"
   },
   "keywords": [
     "debug",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
     "deasync": "^0.1.0",
     "error-stack-parser": "^2.0.1",
     "escope": "^3.6.0",
-    "esprima": "^3.1.3",
+    "esprima": "^4.0.0",
     "estraverse": "^4.2.0",
     "lodash": "^4.17.3",
     "md5": "^2.2.1",
     "parse-stack": "^0.1.4",
-    "prompt": "^0.2.14",
+    "prompt": "^1.0.0",
     "readline-history": "^1.2.0"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "lodash": "^4.17.3",
     "md5": "^2.2.1",
     "mocha": "^4.0.1",
-    "parse-stack": "^0.1.4",
     "prompt": "^1.0.0",
     "readline-history": "^1.2.0",
     "uglify-js": "^3.1.3"

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "parse-stack": "^0.1.4",
     "prompt": "^1.0.0",
     "readline-history": "^1.2.0",
-    "uglify-js": "^3.1.3",
-    "uglifyjs": "^2.4.11"
+    "uglify-js": "^3.1.3"
   },
   "keywords": [
     "debug",

--- a/src/locus.js
+++ b/src/locus.js
@@ -1,13 +1,23 @@
-var fs = require('fs');
-var script = fs.readFileSync(__dirname + '/script.js', 'utf-8');
+const fs = require('fs')
+const script = fs.readFileSync(__dirname + '/script.js', 'utf-8')
 
-// to use in script.js
-global.__locus_modules__ = {
-  deasync: require('deasync'),
-  errorStackParser: require('error-stack-parser'),
-  print: require('./print'),
-  prompt: require('./prompt')
+/**
+ * used in script.js
+ *
+ *
+ */
+
+global.__locus = {
+	running: false,
+	modules: {
+		deasync:          require('deasync'),
+		errorStackParser: require('error-stack-parser'),
+		print:            require('./print'),
+		prompt:           require('./prompt')
+	}
 }
 
-global.__locus_running__ = false;
-global.locus = module.exports = script;
+
+global.__locus_running__ = false
+global.locus = script
+module.exports = script

--- a/src/locus.js
+++ b/src/locus.js
@@ -1,9 +1,13 @@
+
+'use strict'
+
 const fs = require('fs')
 const script = fs.readFileSync(__dirname + '/script.js', 'utf-8')
 
 /**
  * used in script.js
  *
+ * global variables / state accessible throughout the module.
  *
  */
 
@@ -20,4 +24,5 @@ global.__locus = {
 
 global.__locus_running__ = false
 global.locus = script
+
 module.exports = script

--- a/src/locus.js
+++ b/src/locus.js
@@ -4,7 +4,7 @@ var script = fs.readFileSync(__dirname + '/script.js', 'utf-8');
 // to use in script.js
 global.__locus_modules__ = {
   deasync: require('deasync'),
-  parseStack: require('parse-stack'),
+  errorStackParser: require('error-stack-parser'),
   print: require('./print'),
   prompt: require('./prompt')
 }

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -1,0 +1,24 @@
+
+'use strict';
+
+var fs = require('fs');
+var history = './histories';
+
+fs.stat(history, function (err, stat) {
+
+	if (err && err.code !== 'ENOENT') {
+		throw err;
+	}
+
+	if (stat && stat.isFile( )) {
+		throw new Error('please remove the file "' + history + '" so that locus can install correctly');
+	}
+
+	if (!stat) {
+		fs.mkdir(history, function (err) {
+			throw err;
+		});
+	}
+
+});
+

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -1,26 +1,41 @@
 
-'use strict';
+'use strict'
 
-var fs = require('fs');
-var history = './histories';
+const fs = require('fs')
+const path = require('path')
+const history = path.join(__dirname, '../histories')
 
-fs.stat(history, function (err, stat) {
+/**
+ * Create a new history folder in a cross-platform manner.
+ *
+ */
 
-	if (err && err.code !== 'ENOENT') {
-		throw err;
-	}
+function addHistoryFolder ( ) {
 
-	if (stat && stat.isFile( )) {
-		throw new Error('please remove the file "' + history + '" so that locus can install correctly');
-	}
+	fs.stat(history, function (err, stat) {
 
-	if (!stat) {
-		fs.mkdir(history, function (err) {
-			if (err) {
-				throw err;
-			}
-		});
-	}
+		if (err && err.code !== 'ENOENT') {
+			throw err
+		}
 
-});
+		if (stat && stat.isFile( )) {
+			throw new Error('please remove the file "' + history + '" so that locus can install correctly')
+		}
 
+		if (!stat) {
+			fs.mkdir(history, function (err) {
+				if (err) {
+					throw err
+				}
+			})
+		}
+
+	})
+
+}
+
+
+
+
+
+addHistoryFolder( )

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -16,7 +16,9 @@ fs.stat(history, function (err, stat) {
 
 	if (!stat) {
 		fs.mkdir(history, function (err) {
-			throw err;
+			if (err) {
+				throw err;
+			}
 		});
 	}
 

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -37,5 +37,12 @@ function addHistoryFolder ( ) {
 
 
 
+try {
+	addHistoryFolder( )
+} catch (err) {
 
-addHistoryFolder( )
+	console.log('Please report this error to the package maintainer.')
+	console.error(err)
+	process.exit(1)
+
+}

--- a/src/print.js
+++ b/src/print.js
@@ -4,7 +4,7 @@ const util = require('util')
 const color = require('cli-color')
 const highlight = require('cardinal').highlight
 const syntaxTheme = require('cardinal/themes/tomorrow-night.js')
-const _ = require('lodash')
+const (require('lodash'))
 
 
 
@@ -36,7 +36,7 @@ print.file = (path, line) => {
 	var startLine = line > 7 ? line - 7 : 0
 	var lines = file.split('\n')
 
-	// -- todo simplify & remove use of xterm.
+	// -- todo simplify.
 	for (var ith = startLine; ith < line + 3 && ith < lines.length; ith++) {
 
 		var maxLineNumberLength = line.toString( ).length
@@ -47,9 +47,9 @@ print.file = (path, line) => {
 			var lineNumber = ith + 1
 		}
 
-		lineNumber = _.padStart(lineNumber + ': ', maxLineNumberLength + 6)
+		let paddedLineNumber = (lineNumber + ': ').padStart(maxLineNumberLength + 6)
 
-		console.log(color.xterm(111)(lineNumber) + lines[ith])
+		console.log(color.xterm(111)(paddedLineNumber) + lines[ith])
 	}
 
 	console.log()

--- a/src/print.js
+++ b/src/print.js
@@ -1,44 +1,83 @@
-var fs = require('fs');
-var util = require('util');
-var color = require('cli-color');
-var highlight = require('cardinal').highlight;
-var syntaxTheme = require('cardinal/themes/tomorrow-night.js');
-var _ = require('lodash');
 
-exports.file = function(path, line) {
-  var file = highlight(
-    fs.readFileSync(path, 'utf-8'),
-    { theme: syntaxTheme }
-  );
+const fs = require('fs')
+const util = require('util')
+const color = require('cli-color')
+const highlight = require('cardinal').highlight
+const syntaxTheme = require('cardinal/themes/tomorrow-night.js')
+const _ = require('lodash')
 
-  console.log();
-  console.log(color.bold('File : ') + path + ' @ line: ' + line);
-  console.log();
 
-  var startLine = line > 7 ? line - 7 : 0;
-  var lines = file.split('\n');
 
-  for(var i = startLine; i < line + 3 && i < lines.length; i++) {
-    var maxLineNumberLength = line.toString().length;
 
-    if (line === i + 1) {
-      var lineNumber = ' => ' + (i + 1);
-    } else {
-      var lineNumber = i + 1;
-    }
+const print = { }
 
-    lineNumber = _.padStart(lineNumber + ': ', maxLineNumberLength + 6);
 
-    console.log(color.xterm(111)(lineNumber) + lines[i]);
-  }
 
-  console.log();
+
+
+/*
+ * @param {string} path the path to load.
+ * @parm {number} line the current line number in the file.
+ *
+ */
+
+print.file = (path, line) => {
+
+	// -- syntax-highlight the loaded, current, JS file.
+	const file = highlight(fs.readFileSync(path, 'utf-8'), {
+		theme: syntaxTheme
+	})
+
+	// -- display details about the file.
+	console.log( )
+	console.log(color.bold('File : ') + path + ' @ line: ' + line)
+	console.log( )
+
+	var startLine = line > 7 ? line - 7 : 0
+	var lines = file.split('\n')
+
+	for (var ith = startLine; ith < line + 3 && ith < lines.length; ith++) {
+
+		var maxLineNumberLength = line.toString( ).length
+
+		if (line === ith + 1) {
+			var lineNumber = ' => ' + (ith + 1)
+		} else {
+			var lineNumber = ith + 1
+		}
+
+		lineNumber = _.padStart(lineNumber + ': ', maxLineNumberLength + 6)
+
+		console.log(color.xterm(111)(lineNumber) + lines[ith])
+	}
+
+	console.log()
 }
 
-exports.success = function(result) {
-  console.log(color.greenBright(util.inspect(result, false, 1, true)));
+/*
+ * @param {object} result The value returned from the REPL.
+ *
+ * print a stringified result returned from an executed command.
+ *
+ */
+
+print.success = result => {
+	console.log(color.greenBright(util.inspect(result, false, 1, true)))
 }
 
-exports.error = function(err) {
-  console.log(color.redBright(err));
+/*
+ * @param {string} err an error result to display.
+ *
+ * print a error that occurred while running a command.
+ *
+ */
+
+print.error = err => {
+	console.log(color.redBright(err))
 }
+
+
+
+
+
+module.exports = print

--- a/src/print.js
+++ b/src/print.js
@@ -36,6 +36,7 @@ print.file = (path, line) => {
 	var startLine = line > 7 ? line - 7 : 0
 	var lines = file.split('\n')
 
+	// -- todo simplify & remove use of xterm.
 	for (var ith = startLine; ith < line + 3 && ith < lines.length; ith++) {
 
 		var maxLineNumberLength = line.toString( ).length

--- a/src/prompt.js
+++ b/src/prompt.js
@@ -23,7 +23,7 @@ function generateCompleter(filepath) {
     var possibleHints;
 
     if (lineArray.length === 2) {
-      var object = __locus_eval__(lineArray[0]);
+      var object = __locus.eval(lineArray[0]);
       possibleHints = getAllProperties(object).map(function(i) {
         return lineArray[0] + '.' + i;
       });

--- a/src/prompt.js
+++ b/src/prompt.js
@@ -3,7 +3,7 @@ var readline = require('readline-history');
 var md5 = require('md5');
 var color = require('cli-color');
 var deasync = require('deasync');
-var variables = require('./variables');
+var d = require('./d');
 var _ = require('lodash');
 var _rl;
 
@@ -16,7 +16,8 @@ function getAllProperties(obj) {
 }
 
 function generateCompleter(filepath) {
-  var fileVariables = Object.keys(global).concat(variables.get(filepath));
+
+  var filed = Object.keys(global).concat(d.get(filepath));
 
   return function(line) {
     var lineArray = line.split('.');
@@ -30,7 +31,7 @@ function generateCompleter(filepath) {
     } else if (lineArray.length > 2) {
       possibleHints = [];
     } else {
-      possibleHints = fileVariables;
+      possibleHints = filed;
     }
 
     var hits = possibleHints.filter(function(c){

--- a/src/prompt.js
+++ b/src/prompt.js
@@ -3,7 +3,7 @@ var readline = require('readline-history');
 var md5 = require('md5');
 var color = require('cli-color');
 var deasync = require('deasync');
-var d = require('./d');
+var variables = require('./variables');
 var _ = require('lodash');
 var _rl;
 
@@ -16,8 +16,7 @@ function getAllProperties(obj) {
 }
 
 function generateCompleter(filepath) {
-
-  var filed = Object.keys(global).concat(d.get(filepath));
+  var fileVariables = Object.keys(global).concat(variables.getFile(filepath));
 
   return function(line) {
     var lineArray = line.split('.');
@@ -31,7 +30,7 @@ function generateCompleter(filepath) {
     } else if (lineArray.length > 2) {
       possibleHints = [];
     } else {
-      possibleHints = filed;
+      possibleHints = fileVariables;
     }
 
     var hits = possibleHints.filter(function(c){

--- a/src/script.js
+++ b/src/script.js
@@ -17,7 +17,7 @@
 	__locus.modules.print.file(__locus.file, __locus_line__)
 
 	// -- for autocomplete improvements
-	global.__locus_eval__ = function(code) {
+	global.__locus.eval = function(code) {
 		return eval(code)
 	}
 
@@ -30,13 +30,14 @@
 
 		try {
 
-			// -- if an exit code is read, close the repl & exit.
+			// -- if the user enters 'exit', close the prompt & exit.
 			if (locus_code === 'exit') {
 
 				__locus.running = false
 				__locus.modules.prompt.close( )
 
 				break
+
 			} else {
 
 				__locus.modules.print.success(eval(locus_code))

--- a/src/script.js
+++ b/src/script.js
@@ -1,33 +1,52 @@
 
-var __locus_stack__ = __locus_modules__.errorStackParser.parse(new Error());
-var __locus_filepath__ = __locus_stack__[1].fileName;
-var __locus_line__ = __locus_stack__[1].lineNumber;
+/*
+ * start a REPL, and handle user input.
+ *
+ */
 
-__locus_modules__.deasync.loopWhile(function() {
-  return __locus_running__;
-});
+{
 
-__locus_modules__.print.file(__locus_filepath__, __locus_line__);
+	// -- capture details about the current file location.
 
-// for autocomplete improvements
-global.__locus_eval__ = function(code) {
-  return eval(code);
-}
+	const stack = __locus.modules.errorStackParser.parse(new Error( ))
 
-while (true) {
-  __locus_running__ = true;
+	const __locus.file = stack[1].fileName
+	const __locus.line = stack[1].lineNumber
 
-  var __locus_code__ = __locus_modules__.prompt.get(__locus_filepath__);
+	__locus.modules.deasync.loopWhile(( ) => __locus.running)
+	__locus.modules.print.file(__locus.file, __locus_line__)
 
-  try {
-    if (__locus_code__ === 'exit') {
-      __locus_running__ = false;
-      __locus_modules__.prompt.close();
-      break;
-    } else {
-      __locus_modules__.print.success(eval(__locus_code__));
-    }
-  } catch(err) {
-    __locus_modules__.print.error(err);
-  }
+	// -- for autocomplete improvements
+	global.__locus_eval__ = function(code) {
+		return eval(code)
+	}
+
+	// -- read user input in A REPL.
+	while (true) {
+
+		__locus.running = true
+
+		let locus_code = __locus.modules.prompt.get(__locus.file)
+
+		try {
+
+			// -- if an exit code is read, close the repl & exit.
+			if (locus_code === 'exit') {
+
+				__locus.running = false
+				__locus.modules.prompt.close( )
+
+				break
+			} else {
+
+				__locus.modules.print.success(eval(locus_code))
+
+			}
+
+		} catch(err) {
+			__locus.modules.print.error(err)
+		}
+
+	}
+
 }

--- a/src/script.js
+++ b/src/script.js
@@ -1,5 +1,6 @@
-var __locus_stack__ = __locus_modules__.parseStack(new Error());
-var __locus_filepath__ = __locus_stack__[1].filepath;
+
+var __locus_stack__ = __locus_modules__.errorStackParser(new Error());
+var __locus_filepath__ = __locus_stack__[1].fileName;
 var __locus_line__ = __locus_stack__[1].lineNumber;
 
 __locus_modules__.deasync.loopWhile(function() {

--- a/src/script.js
+++ b/src/script.js
@@ -1,5 +1,5 @@
 
-var __locus_stack__ = __locus_modules__.errorStackParser(new Error());
+var __locus_stack__ = __locus_modules__.errorStackParser.parse(new Error());
 var __locus_filepath__ = __locus_stack__[1].fileName;
 var __locus_line__ = __locus_stack__[1].lineNumber;
 

--- a/src/variables.js
+++ b/src/variables.js
@@ -1,8 +1,10 @@
-var escope = require('escope');
-var esprima = require('esprima');
-var estraverse = require('estraverse');
-var fs = require('fs');
-var _ = require('lodash');
+
+'use strict'
+
+const escope = require('escope');
+const esprima = require('esprima');
+const estraverse = require('estraverse');
+const fs = require('fs');
 
 
 
@@ -13,7 +15,7 @@ const variables = { }
 /**
  * List all variables in a JS string.
  *
- * @param {string} text
+ * @param {string} text the text to parse.
  *
  * @example
  *   variables.getString('let x = 1') // new Set(['x'])
@@ -22,13 +24,13 @@ const variables = { }
  *
  */
 
-variables.getString = function getString (text) {
+variables.getString = function getString (text, strict = false) {
 
 	const variables = [ ]
 
 	try {
 
-		var ast = esprima.parse(text)
+		const ast = esprima.parse(text)
 
 		const scopeManager = escope.analyze(ast)
 		const currentScope = scopeManager.acquire(ast)
@@ -50,7 +52,13 @@ variables.getString = function getString (text) {
 		})
 
 
-	} catch (err) { }
+	// no need to display parse-errors.
+
+	} catch (err) {
+		if (strict) {
+			throw err
+		}
+	}
 
 	return new Set(variables)
 
@@ -60,7 +68,7 @@ variables.getString = function getString (text) {
 /**
  * List all variables in a JS file.
  *
- * @param {string} path
+ * @param {string} filepath the path to load.
  *
  * @example
  *   variables.getFile('foo.js')

--- a/src/variables.js
+++ b/src/variables.js
@@ -4,31 +4,56 @@ var estraverse = require('estraverse');
 var fs = require('fs');
 var _ = require('lodash');
 
-exports.get = function(filepath) {
-  var variables = [];
 
-  try {
-    var ast = esprima.parse(fs.readFileSync(filepath, 'utf-8'));
-  } catch(e) {
-    return [];
-  }
 
-  var scopeManager = escope.analyze(ast);
-  var currentScope = scopeManager.acquire(ast);
 
-  estraverse.traverse(ast, {
-    leave: function(node, parent) {
-      var scope = scopeManager.acquire(node);
 
-      if (scope) {
-        var nodeVariables = _.values(scope.variables).map(function(item) {
-          return item.name;
-        });
+const variables = { }
 
-        variables = variables.concat(nodeVariables)
-      }
-    }
-  });
+/*
+ * @param {string} text
+ */
 
-  return _.uniq(variables);
+variables.getString = function get (text) {
+
+	const variables = [ ]
+
+	try {
+
+		var ast = esprima.parse(text)
+
+		const scopeManager = escope.analyze(ast)
+		const currentScope = scopeManager.acquire(ast)
+
+		estraverse.traverse(ast, {
+			leave: function traverseAst (node, parent) {
+
+				const scope = scopeManager.acquire(node)
+
+				if (scope) {
+
+					scope.variables.forEach(variable => {
+						variables.push(variable.name)
+					})
+
+				}
+
+			}
+		})
+
+
+	} catch (err) { }
+
+	return new Set(variables)
+
 }
+
+variables.getFile = function get (filepath) {
+	return variables.getString(fs.readFileSync(filepath, 'utf-8'))
+}
+
+
+
+
+
+module.exports = variables

--- a/src/variables.js
+++ b/src/variables.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const escope = require('escope');
-const esprima = require('esprima');
+const espree = require('espree');
 const estraverse = require('estraverse');
 const fs = require('fs');
 
@@ -30,7 +30,7 @@ variables.getString = function getString (text, strict = false) {
 
 	try {
 
-		const ast = esprima.parse(text)
+		const ast = espree.parse(text)
 
 		const scopeManager = escope.analyze(ast)
 		const currentScope = scopeManager.acquire(ast)
@@ -51,8 +51,7 @@ variables.getString = function getString (text, strict = false) {
 			}
 		})
 
-
-	// no need to display parse-errors.
+	// -- no need to display parse-errors.
 
 	} catch (err) {
 		if (strict) {

--- a/src/variables.js
+++ b/src/variables.js
@@ -30,7 +30,9 @@ variables.getString = function getString (text, strict = false) {
 
 	try {
 
-		const ast = espree.parse(text)
+		const ast = espree.parse(text, {
+			ecmaVersion: 9
+		})
 
 		const scopeManager = escope.analyze(ast)
 		const currentScope = scopeManager.acquire(ast)

--- a/src/variables.js
+++ b/src/variables.js
@@ -10,11 +10,19 @@ var _ = require('lodash');
 
 const variables = { }
 
-/*
+/**
+ * List all variables in a JS string.
+ *
  * @param {string} text
+ *
+ * @example
+ *   variables.getString('let x = 1') // new Set(['x'])
+ *
+ * @returns {set} a set of variable names contained in the program.
+ *
  */
 
-variables.getString = function get (text) {
+variables.getString = function getString (text) {
 
 	const variables = [ ]
 
@@ -48,7 +56,20 @@ variables.getString = function get (text) {
 
 }
 
-variables.getFile = function get (filepath) {
+
+/**
+ * List all variables in a JS file.
+ *
+ * @param {string} path
+ *
+ * @example
+ *   variables.getFile('foo.js')
+ *
+ * @returns {set} a set of variable names contained in the program.
+ *
+ */
+
+variables.getFile = function getFile (filepath) {
 	return variables.getString(fs.readFileSync(filepath, 'utf-8'))
 }
 

--- a/test/test-variables.js
+++ b/test/test-variables.js
@@ -30,13 +30,33 @@ describe('variables.get', function ( ) {
 
 	})
 
-	it('never crashes for random programs', done => {
+	it('reports very few parse errors for random ASTs', done => {
 
-		for (let ith = 0; ith < constants.tests.variables.randomCaseCount; ith++) {
-			lib.getString(randomProgram( ))
+		const state = {
+			failed:    0,
+			total:     0,
 		}
 
-		done( )
+		for (let ith = 0; ith < constants.tests.variables.randomCaseCount; ith++) {
+
+			try {
+				state.total++
+				lib.getString(randomProgram( ), true)
+			} catch (err) {
+				if (err) {
+					state.failed++
+				}
+			}
+
+		}
+
+		const percentFailed = state.failed / state.total
+
+		if (percentFailed > constants.tests.variables.failedParseThreshold) {
+			done(new Error(`failed for ${ (percentFailed * 100).toFixed(2) }% of programs.`))
+		} else {
+			done( )
+		}
 
 	})
 

--- a/test/test-variables.js
+++ b/test/test-variables.js
@@ -39,11 +39,15 @@ describe('variables.get', function ( ) {
 
 		for (let ith = 0; ith < constants.tests.variables.randomCaseCount; ith++) {
 
+			let program = randomProgram( )
+
 			try {
 				state.total++
-				lib.getString(randomProgram( ), true)
+				lib.getString(program, true)
 			} catch (err) {
 				if (err) {
+					console.log(err)
+					console.log(program)
 					state.failed++
 				}
 			}

--- a/test/test-variables.js
+++ b/test/test-variables.js
@@ -1,0 +1,43 @@
+
+'use strict'
+
+const lib = require('../src/variables')
+const {expect} = require('chai')
+const esfuzz = require('esfuzz')
+const ugly   = require('uglify-js')
+const constants = require('../constants')
+
+
+
+
+function randomProgram ( ) {
+
+	return ugly.AST_Node.from_mozilla_ast(esfuzz.generate( )).print_to_string( )
+
+}
+
+
+
+
+describe('variables.get', function ( ) {
+
+	this.timeout(constants.tests.variables.duration)
+
+	it('correctly parses variables', ( ) => {
+
+		expect(lib.getString(`let x = 1`)).to.include('x')
+		expect(lib.getString(`let x = 1; const y = 1`)).to.include('y')
+
+	})
+
+	it('never crashes for random programs', done => {
+
+		for (let ith = 0; ith < constants.tests.variables.randomCaseCount; ith++) {
+			lib.getString(randomProgram( ))
+		}
+
+		done( )
+
+	})
+
+})

--- a/test/test-variables.js
+++ b/test/test-variables.js
@@ -20,8 +20,10 @@ function randomProgram ( ) {
 
 	for (let ith = 0; ith < count; ++ith) {
 
+		let declarationType = ['var', 'const', 'let'][ (Math.floor(3 * Math.random( ))) ]
+
 		program.variables.add(`x${ith}`)
-		program.code += `\nlet x${ith} = 1;`
+		program.code += `\n${declarationType} x${ith} = 1;`
 	}
 
 	return program
@@ -41,7 +43,7 @@ describe('variables.get', function ( ) {
 
 			let program = randomProgram( )
 
-			const foundSet = lib.getString(program.code)
+			const foundSet = lib.getString(program.code, true)
 			let missing = [...program.variables].filter(variable => {
 				return !foundSet.has(variable)
 			})


### PR DESCRIPTION
I ran into problems with the existing post install script, `mkdir ./histories`, when running this command repeatedly. Running mkdir twice without `-p` set causes an error to be thrown, making re-installs unreliable. 

I rewrote the script in node.js for better cross-platform compatibility with Windows, which I unfortunately need to debug on in work. 

If you have any suggested edits let me know & I'll apply them quickly. Thanks for creating such a useful library!
